### PR TITLE
Added queueing info to the Sneak command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,13 +12,13 @@
     ],
     "require": {
         "php": ">=7.3",
-        "illuminate/support": "^8.0 | ^9.0 | ^10.0 | ^11.0",
-        "illuminate/view": "^8.0 | ^9.0 | ^10.0 | ^11.0",
-        "illuminate/config": "^8.0 | ^9.0 | ^10.0 | ^11.0",
-        "illuminate/mail": "^8.0 | ^9.0 | ^10.0 | ^11.0",
-        "illuminate/log": "^8.0 | ^9.0 | ^10.0 | ^11.0",
-        "illuminate/queue": "^8.0 | ^9.0 | ^10.0 | ^11.0",
-        "illuminate/console": "^8.0 | ^9.0 | ^10.0 | ^11.0",
+        "illuminate/support": "^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+        "illuminate/view": "^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+        "illuminate/config": "^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+        "illuminate/mail": "^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+        "illuminate/log": "^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+        "illuminate/queue": "^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
+        "illuminate/console": "^8.0 | ^9.0 | ^10.0 | ^11.0 | ^12.0",
         "symfony/error-handler": "~5.1 | ^6.0 | ^7.0"
     },
     "require-dev": {

--- a/src/Commands/Sneak.php
+++ b/src/Commands/Sneak.php
@@ -57,6 +57,11 @@ class Sneak extends Command
             app('sneaker')->captureException(new DummyException, true);
 
             $this->info('Sneaker is working fine ✅');
+
+            if (($queue = config('queue.default')) !== 'sync') {
+                $this->warn('The exception mail has been queued on the "'.$queue.'" queue.');
+                $this->warn('Make sure you have queue workers running to deliver the email.');
+            }
         } catch (Exception $e) {
             (new ConsoleApplication)->renderThrowable($e, $this->output);
         }


### PR DESCRIPTION
I've spend too much time trying to figure out why I did not receive the test email when running `php artisan sneaker:sneak`, even though the terminal showed `Sneaker is working fine ✅`. Turned out I was using the queue, or queue was just not set to sync, and there were no workers running.

So, now, when the default queue is not set to 'sync', when running `php artisan sneaker:sneak` a warning is shown in the console to alert the user that the email has been pushed to the queue and not sent immediately.

